### PR TITLE
Add white spaces to new German translation

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -172,18 +172,18 @@ zh-HK:
 # German / Deutsch
 # ----------------
 de: &DEFAULT_DE
-  comments_label : "Hinterlasse einen Kommentar"
-  comments_title : "Kommentare"
-  comment_form_info : "Die E-Mail Adresse wird nicht veröffentlicht. Benötigte Felder sind markiert"
+  comments_label             : "Hinterlasse einen Kommentar"
+  comments_title             : "Kommentare"
+  comment_form_info          : "Die E-Mail Adresse wird nicht veröffentlicht. Benötigte Felder sind markiert"
   comment_form_comment_label : "Kommentar"
-  comment_form_md_info : "Markdown wird unterstützt."
-  comment_form_name_label : "Name"
-  comment_form_email_label : "E-Mail-Adresse"
+  comment_form_md_info       : "Markdown wird unterstützt."
+  comment_form_name_label    : "Name"
+  comment_form_email_label   : "E-Mail-Adresse"
   comment_form_website_label : "Webseite (optional)"
-  comment_btn_submit : "Kommentar absenden"
-  comment_btn_submitted : "Versendet"
-  comment_success_msg : "Danke für den Kommentar! Er wird nach Prüfung auf der Seite angezeigt."
-  comment_error_msg : "Entschuldigung, es gab einen Fehler. Bitte fülle alle benötigten Felder aus und versuche es erneut."
+  comment_btn_submit         : "Kommentar absenden"
+  comment_btn_submitted      : "Versendet"
+  comment_success_msg        : "Danke für den Kommentar! Er wird nach Prüfung auf der Seite angezeigt."
+  comment_error_msg          : "Entschuldigung, es gab einen Fehler. Bitte fülle alle benötigten Felder aus und versuche es erneut."
 de-DE:
   <<: *DEFAULT_DE
 de-AT:


### PR DESCRIPTION
As Requested by daattali, I reinserted the white space in the new German translation block.